### PR TITLE
Remove obsolete global `words` variable to fix Aikoyori's Shenanigans compatibility

### DIFF
--- a/reverse_tarot.lua
+++ b/reverse_tarot.lua
@@ -221,7 +221,6 @@ function evaluate_poker_hand(hand)
     local omni = {}
     local best_hand = nil
     for i=1, #hand, 1 do
-        words = {}
         if hand[i].ability.name and not hand[i].debuff  then
             if is_omnirank(hand[i]) then
                 table.insert(omni, i)


### PR DESCRIPTION
The issue was that one couldn't form any words with Aikoyori's Shenanigans' letter cards anymore.

Aikoyori's Shenanigans uses a global `words` variable as well, which was reset to `{}` here. At some chnage 3 months ago, the `words = {}` part was kept in but I don't think it is of any use anymore.

If I understood the code correctly, just removing it should be fine, so I did exactly that.